### PR TITLE
remove spaces in md links on usecases page

### DIFF
--- a/usecases.md
+++ b/usecases.md
@@ -50,8 +50,8 @@ user supplied modeling assumptions and actual weather data.
 #### 1.A. Calculate predicted performance {#uc1A}
 {: .anchor}
 
-**Use case narrative**: Using an [SPI Performance Model] (#performancemodels) with user-provided modeling assumptions,
-user input system metadata, and [user-supplied weather data] (#uc6a), calculate system output.
+**Use case narrative**: Using an [SPI Performance Model](#performancemodels) with user-provided modeling assumptions,
+user input system metadata, and [user-supplied weather data](#uc6a), calculate system output.
 
 **Requirements**:
 
@@ -65,7 +65,7 @@ user input system metadata, and [user-supplied weather data] (#uc6a), calculate 
 {: .anchor}
 
 **Use case narrative**: Using an [SPI Performance Model](#performancemodels) with user-provided modeling assumptions,
-user input system metadata, [user-uploaded actual weather data] (#uc6a), and user-selected [data quality checks](#uc6b),
+user input system metadata, [user-uploaded actual weather data](#uc6a), and user-selected [data quality checks](#uc6b),
 calculate system output.
 
 **Requirements**:


### PR DESCRIPTION
While reading through the Usecases, I noticed a couple of links that weren't rendering properly. Looks like they just had an extra space so I removed them. A grep of the repo suggests these are the only cases of that issue. 