### PR TITLE
Use case links with uppercase sub-headings

### DIFF
--- a/usecases.md
+++ b/usecases.md
@@ -51,7 +51,7 @@ user supplied modeling assumptions and actual weather data.
 {: .anchor}
 
 **Use case narrative**: Using an [SPI Performance Model](#performancemodels) with user-provided modeling assumptions,
-user input system metadata, and [user-supplied weather data](#uc6a), calculate system output.
+user input system metadata, and [user-supplied weather data](#uc6A), calculate system output.
 
 **Requirements**:
 
@@ -65,7 +65,7 @@ user input system metadata, and [user-supplied weather data](#uc6a), calculate s
 {: .anchor}
 
 **Use case narrative**: Using an [SPI Performance Model](#performancemodels) with user-provided modeling assumptions,
-user input system metadata, [user-uploaded actual weather data](#uc6a), and user-selected [data quality checks](#uc6b),
+user input system metadata, [user-uploaded actual weather data](#uc6A), and user-selected [data quality checks](#uc6B),
 calculate system output.
 
 **Requirements**:


### PR DESCRIPTION
Should have been more thorough in my last PR. This fixes broken link href attributes to link to the correct use cases.